### PR TITLE
feat: if keyword_pattern is matched, convert insertText to textEdit

### DIFF
--- a/lua/blink/compat/lib/utils.lua
+++ b/lua/blink/compat/lib/utils.lua
@@ -1,0 +1,15 @@
+local utils = {}
+
+--- Shallow copy table
+--- @generic T
+--- @param t T
+--- @return T
+function utils.shallow_copy(t)
+  local t2 = {}
+  for k, v in pairs(t) do
+    t2[k] = v
+  end
+  return t2
+end
+
+return utils

--- a/lua/blink/compat/source.lua
+++ b/lua/blink/compat/source.lua
@@ -61,6 +61,7 @@ function source:get_completions(ctx, callback)
     group_index = nil,
     entry_filter = nil,
   }
+
   local function transformed_callback(candidates)
     if candidates == nil then
       callback()
@@ -75,6 +76,26 @@ function source:get_completions(ctx, callback)
           name = self.config.name,
           source = s,
         }, { __index = s })
+
+        return item
+      end, items)
+    end
+
+    if keyword_start then
+      local range = {
+        start = { line = cmp_ctx.cursor.line, character = keyword_start - 1 },
+        ['end'] = { line = cmp_ctx.cursor.line, character = keyword_end },
+      }
+
+      items = vim.tbl_map(function(item)
+        if item.textEdit or item.textEditText then return item end
+        local word = item.insertText or item.label
+
+        item.insertText = nil
+        item.textEdit = {
+          range = range,
+          newText = word,
+        }
 
         return item
       end, items)

--- a/lua/blink/compat/source.lua
+++ b/lua/blink/compat/source.lua
@@ -1,6 +1,7 @@
 local registry = require('blink.compat.registry')
 local context = require('blink.compat.lib.context')
 local pattern = require('blink.compat.lib.pattern')
+local utils = require('blink.compat.lib.utils')
 
 local source = {}
 
@@ -89,6 +90,10 @@ function source:get_completions(ctx, callback)
 
       items = vim.tbl_map(function(item)
         if item.textEdit or item.textEditText then return item end
+
+        -- some sources reuse items, so copy to avoid setting textEdit on them
+        item = utils.shallow_copy(item)
+
         local word = item.insertText or item.label
 
         item.insertText = nil

--- a/lua/blink/compat/source.lua
+++ b/lua/blink/compat/source.lua
@@ -85,7 +85,7 @@ function source:get_completions(ctx, callback)
     if keyword_start then
       local range = {
         start = { line = cmp_ctx.cursor.line, character = keyword_start - 1 },
-        ['end'] = { line = cmp_ctx.cursor.line, character = keyword_end },
+        ['end'] = { line = cmp_ctx.cursor.line, character = keyword_end - 1 },
       }
 
       items = vim.tbl_map(function(item)


### PR DESCRIPTION
This should fix cases where part of a keyword is left after a completion is inserted.

For instance, using `cmp-emoji`, typing ":thumbsup" and accepting the completion results in ": :+1:"

Currently running into two errors:

- [x] ~~ghost text `invalid 'col': out of range` when completing on end of line - probably related to https://github.com/Saghen/blink.cmp/issues/257~~ range end character index was set incorrectly
- [x] ~~the second completion is always inserted with the range of the previous completion. Are completions (and specifically the `range` of the textEdit) being incorrectly cached across contexts when they shouldn't be? This happens even across files, and even when both `is_incomplete` fields on CompletionResponse are set to true.~~ `cmp-emoji` reused returned items, so setting `textEdit` once meant the item being skipped the second time. fixed with a shallow copy