### PR TITLE
feat: add dummy entry fields to make compatible with autopairs

### DIFF
--- a/lua/blink/compat/init.lua
+++ b/lua/blink/compat/init.lua
@@ -26,7 +26,12 @@ local function setup_events()
   local function make_entry(item)
     -- NOTE: only events emmited by blink.compat sources will have a `source`
     return {
-      entry = { completion_item = item, source = item._source or {} },
+      entry = {
+        completion_item = item,
+        source = item._source or {},
+        get_commit_characters = function() return {} end,
+        get_completion_item = function() return item end,
+      },
     }
   end
 


### PR DESCRIPTION
Hi, I‌ was getting errors from `nvim-autopairs` (I can't get blink's autopair to work) and after playing with the code for a bit, I managed to fix it. Figured you might appreciate it here.