### PR TITLE
Fix name of can_execute to match what blink.cmp expects

### DIFF
--- a/lua/blink/compat/source.lua
+++ b/lua/blink/compat/source.lua
@@ -130,7 +130,7 @@ function source:resolve(item, callback)
   s:resolve(item, callback)
 end
 
-function source:can_execute()
+function source:should_execute()
   local s = self:_get_source()
   return s ~= nil and s.execute ~= nil
 end


### PR DESCRIPTION
This method should be called should_execute according to the code in blink.cmp