### PR TITLE
docs: update sources section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,8 @@ return {
       { 'dmitmel/cmp-digraphs' },
     },
     sources = {
-      completion = {
-        -- remember to enable your providers here
-        enabled_providers = { 'lsp', 'path', 'snippets', 'buffer', 'digraphs' },
-      },
-
+      -- remember to enable your providers here
+      defaults = { 'lsp', 'path', 'snippets', 'buffer', 'digraphs' },
       providers = {
         -- create provider
         digraphs = {


### PR DESCRIPTION
`sources.completion.enabled_providers` has been moved to `sources.default` in blink.cmp version 0.8.0:
https://github.com/Saghen/blink.cmp/blob/0f92fb8dcff634e880a60e266f041dfe175b82bf/CHANGELOG.md?plain=1#L4