### PR TITLE
fix: ensure item is a table before indexing

### DIFF
--- a/lua/blink/compat/source.lua
+++ b/lua/blink/compat/source.lua
@@ -84,7 +84,7 @@ function source:get_completions(ctx, callback)
       }
 
       items = vim.tbl_map(function(item)
-        if item.textEdit or item.textEditText then return item end
+        if type(item) ~= 'table' or item.textEdit or item.textEditText then return item end
 
         -- some sources reuse items, so copy to avoid setting textEdit on them
         item = utils.shallow_copy(item)


### PR DESCRIPTION
Fixes `failed to get completions with error: blink.compat/lua/blink/compat/source.lua:87: attempt to index local 'item' (a boolean value)` when trying to use blink.compat with Obsidian.nvim.