### PR TITLE
Add simple `cmp.get_config` implementation

### DIFF
--- a/lua/cmp/init.lua
+++ b/lua/cmp/init.lua
@@ -14,6 +14,12 @@ cmp.event = cmp.core.event
 ---Expose setup
 cmp.setup = require('cmp.setup')
 
+cmp.get_config = function()
+  -- Workaround for plugins that use `cmp.get_config` to inject their
+  -- own cmp source (e.g. obsidian.nvim).
+  return { sources = require('blink.compat.registry').sources }
+end
+
 function cmp.register_source(name, s)
   require('blink.compat.registry').register_source(name, s)
   -- use name as id


### PR DESCRIPTION
Obsidian.nvim uses `get_config` to inject their cmp source [here](https://github.com/epwalsh/obsidian.nvim/blob/main/lua/obsidian/init.lua#L151), which causes this bug: https://github.com/epwalsh/obsidian.nvim/issues/793

This PR adds a simple implementation of `get_config` that fixes the issue for obsidian.nvim and will now work out of the box.