### PR TITLE
Add default core.filter to prevent lsp_signature's error.

### DIFF
--- a/lua/cmp/core.lua
+++ b/lua/cmp/core.lua
@@ -5,4 +5,10 @@ function core.view.visible() return require('blink.cmp.completion.windows.menu')
 
 core.event = require('blink.compat.event')
 
+core.filter = core.filter or {
+  sync = function(_, timeout_)
+    vim.wait(timeout_ or 1000, function() end, 10)
+  end,
+}
+
 return core


### PR DESCRIPTION
Fix https://github.com/Saghen/blink.compat/issues/25