### PR TITLE
fix: add compatibility with cmp-buffer

### DIFF
--- a/lua/blink/compat/source.lua
+++ b/lua/blink/compat/source.lua
@@ -43,7 +43,7 @@ function source:get_completions(ctx, callback)
   if s == nil or s.complete == nil then return callback() end
 
   local keyword_pattern
-  if s.get_keyword_pattern then keyword_pattern = s:get_keyword_pattern() end
+  if s.get_keyword_pattern then keyword_pattern = s:get_keyword_pattern({ option = self.config.opts or {} }) end
 
   local cmp_ctx = context.new(ctx)
 


### PR DESCRIPTION
cmp-buffer expects the param given to `get_keyword_pattern` is an object with a option field, so we fulfill that requirement in this PR.

I know that the recommendation is to use the builtin `blink.cmp` `buffer` completion, but it takes the completions from all buffers and appears to be a bit flaky in that it doesn't get all the buffer words. It would probably be better to fix this issue, but this was easier for me and figured it doesn't hurt sharing it.
